### PR TITLE
Markdown Additions: Notices of Optionality

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,6 +4,9 @@ Something went wrong and should be reported.
 All text put inside < !-- and -- > (spaces on bigger side removed) are not visible when submitted.
 Don't put any text for the actual bug report inside these.
 Check to make sure this isn't a duplicate issue.
+
+If you feel like this issue template is pointless for your issue (i.e. too small to put in it's own issue) just press CTRL-A and delete all the content.
+This is only a suggestion for how it should be done, you do not need to abide by it.
 -->
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 # Pull Request
-<!-- Thanks for contributing to MCsniperGO! Please fill this out so the PR can be merged faster. -->
+<!-- Thanks for contributing to MCsniperGO! Please fill this out so the PR can be merged faster. 
+If this is a minor PR, don't bother with the template. Just CTRL-A + backspace and fill out as you wish.
+-->
 
 ## PR status
 <!-- This section has checkboxes for the status of the PR. Update them, add some, or remove some as needed. -->


### PR DESCRIPTION
Yeah, these templates are annoying for smaller PRs and issues. Adding a notice in the first comment for both may help
make people realize these aren't required, only suggested by a contributor 😥

[section removed, pointless for a markdown edit]

Check commits if you want to see the messages.