### PR TITLE
Update claimer.go

### DIFF
--- a/claimer/claimer.go
+++ b/claimer/claimer.go
@@ -104,7 +104,7 @@ func claimName(claim ClaimAttempt, client *fasthttp.Client) {
 	var fail mc.FailType = mc.DUPLICATE
 
 	if strings.HasPrefix(claim.Proxy, "socks5://") {
-		client.Dial = fasthttpproxy.FasthttpSocksDialer(strings.TrimPrefix(claim.Proxy, "socks5://"))
+		client.Dial = fasthttpproxy.FasthttpSocksDialer(claim.Proxy)
 	} else if claim.Proxy != "" {
 		client.Dial = fasthttpproxy.FasthttpHTTPDialer(claim.Proxy)
 	}


### PR DESCRIPTION
https://github.com/valyala/fasthttp/issues/1627
needs the socks5:// prefix
seems to be working if you store in proxies.txt in the format "socks5://user:pass@address:port"