### PR TITLE
Re-add 2FA support

### DIFF
--- a/mc/msa.go
+++ b/mc/msa.go
@@ -80,6 +80,11 @@ type msGetMojangBearerResponse struct {
 
 func (account *MCaccount) MicrosoftAuthenticate(proxy string) error {
 
+	if account.Password == "code" {
+		go account.OauthFlow()
+		return nil
+	}
+
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
If the password is set to `code`, it'll branch off to the oauth2 device code login.